### PR TITLE
Added import statements for numpy and astropy.io.fits in example 2.

### DIFF
--- a/01_README.ipynb
+++ b/01_README.ipynb
@@ -82,9 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import nghxrg as ng"
@@ -111,9 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate a noise generator object for NIRSpec H2RGs. You\n",
@@ -148,11 +144,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "from astropy.io import fits\n",
+    "\n",
     "# Setup\n",
     "i_dark = 0.005# e-/s/pix\n",
     "t = 934.# s\n",
@@ -185,9 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "## Instantiate a new object, this time a 2048x2048x88 pixel cube\n",
@@ -222,9 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "## Setup\n",
@@ -271,9 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use parameters that generate noise similar to JWST NIRSpec\n",
@@ -300,9 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use parameters that generate noise similar to JWST NIRSpec\n",
@@ -329,9 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a new instance with reversed fast scanners\n",
@@ -360,9 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Open the fits file\n",
@@ -398,9 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate a new object on account of the different array dimensions.\n",
@@ -435,9 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate a new object having the correct dimensions. HxRG detectors read subarrays\n",
@@ -478,9 +459,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Hey Bernie, took a look at this and worked through the examples in the jupyter notebook. I found that a few imports were missing, and I added them in. Take a look at this pull request and accept the changes when you get a chance.